### PR TITLE
perf: optimize work with collections

### DIFF
--- a/ft-logic/io/src/lib.rs
+++ b/ft-logic/io/src/lib.rs
@@ -23,7 +23,7 @@ pub struct FTLogicState {
     pub transaction_status: Vec<(H256, TransactionStatus)>,
     pub instructions: Vec<(H256, (Instruction, Instruction))>,
     pub storage_code_hash: H256,
-    pub id_to_storage: Vec<(u8, Option<ActorId>)>,
+    pub id_to_storage: [Option<ActorId>; 16],
 }
 
 #[derive(Encode, Decode, TypeInfo, Clone, Debug)]

--- a/ft-logic/io/src/lib.rs
+++ b/ft-logic/io/src/lib.rs
@@ -23,7 +23,7 @@ pub struct FTLogicState {
     pub transaction_status: Vec<(H256, TransactionStatus)>,
     pub instructions: Vec<(H256, (Instruction, Instruction))>,
     pub storage_code_hash: H256,
-    pub id_to_storage: Vec<(String, ActorId)>,
+    pub id_to_storage: Vec<(u8, Option<ActorId>)>,
 }
 
 #[derive(Encode, Decode, TypeInfo, Clone, Debug)]

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -333,10 +333,14 @@ impl FTLogic {
         self.storage_code_hash = storage_code_hash;
     }
 
+    fn get_id_for_account(account: &ActorId) -> usize{
+        (account.as_ref()[0] / 16) as usize
+    }
+
     fn get_storage_address(&mut self, address: &ActorId) -> ActorId {
         // let encoded = hex::encode(address.as_ref()[0..=0]);
         // let id: String = encoded.chars().next().expect("Can't be None").to_string();
-        let id = (address.as_ref()[0] / 16) as usize;
+        let id = Self::get_id_for_account(address);
         if let Some(ref address) = self.id_to_storage[id] {
             *address
         } else {
@@ -355,7 +359,7 @@ impl FTLogic {
     async fn get_permit_id(&self, account: &ActorId) {
         // let encoded = hex::encode(account.as_ref()[0..=0]);
         // let id: String = encoded.chars().next().expect("Can't be None").to_string();
-        let id = (account.as_ref()[0] / 16) as usize;
+        let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             let permit_id = get_permit_id(address, account).await;
             msg::reply(FTLogicEvent::PermitId(permit_id), 0)
@@ -374,7 +378,7 @@ impl FTLogic {
     ) -> bool {
         // let encoded = hex::encode(account.as_ref()[0..=0]);
         // let id: String = encoded.chars().next().expect("Can't be None").to_string();
-        let id = (account.as_ref()[0] / 16) as usize;
+        let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             return check_and_increment_permit_id(address, transaction_hash, account, *expected_id)
                 .await;
@@ -385,7 +389,7 @@ impl FTLogic {
     async fn get_balance(&self, account: &ActorId) {
         // let encoded = hex::encode(account.as_ref()[0..=0]);
         // let id: String = encoded.chars().next().expect("Can't be None").to_string();
-        let id = (account.as_ref()[0] / 16) as usize;
+        let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             let balance = get_balance(address, account).await;
             msg::reply(FTLogicEvent::Balance(balance), 0)
@@ -486,10 +490,10 @@ extern "C" fn state() {
         storage_code_hash: logic.storage_code_hash,
         id_to_storage: logic
             .id_to_storage
-            .iter()
-            .enumerate()
-            .map(|(key, value)| (key as u8, *value))
-            .collect(),
+            // .iter()
+            // .enumerate()
+            // .map(|(key, value)| (key as u8, *value))
+            // .collect(),
     };
     msg::reply(logic_state, 0).expect("Failed to share state");
 }

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -338,8 +338,8 @@ impl FTLogic {
 
     fn get_storage_address(&mut self, address: &ActorId) -> ActorId {
         let id = Self::get_id_for_account(address);
-        if let Some(ref address) = self.id_to_storage[id] {
-            *address
+        if let Some(address) = self.id_to_storage[id] {
+            address
         } else {
             let (_message_id, address) = ProgramGenerator::create_program_with_gas(
                 self.storage_code_hash.into(),

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -332,7 +332,7 @@ impl FTLogic {
         self.storage_code_hash = storage_code_hash;
     }
 
-    fn get_id_for_account(account: &ActorId) -> usize{
+    fn get_id_for_account(account: &ActorId) -> usize {
         (account.as_ref()[0] / 16) as usize
     }
 

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -333,7 +333,7 @@ impl FTLogic {
     }
 
     fn get_storage_address(&mut self, address: &ActorId) -> ActorId {
-        let encoded = hex::encode(address.as_ref());
+        let encoded = hex::encode(address.as_ref()[0..=0]);
         let id: String = encoded.chars().next().expect("Can't be None").to_string();
         if let Some(address) = self.id_to_storage.get(&id) {
             *address
@@ -351,7 +351,7 @@ impl FTLogic {
     }
 
     async fn get_permit_id(&self, account: &ActorId) {
-        let encoded = hex::encode(account.as_ref());
+        let encoded = hex::encode(account.as_ref()[0..=0]);
         let id: String = encoded.chars().next().expect("Can't be None").to_string();
         if let Some(address) = self.id_to_storage.get(&id) {
             let permit_id = get_permit_id(address, account).await;
@@ -369,7 +369,7 @@ impl FTLogic {
         account: &ActorId,
         expected_id: &u128,
     ) -> bool {
-        let encoded = hex::encode(account.as_ref());
+        let encoded = hex::encode(account.as_ref()[0..=0]);
         let id: String = encoded.chars().next().expect("Can't be None").to_string();
         if let Some(address) = self.id_to_storage.get(&id) {
             return check_and_increment_permit_id(address, transaction_hash, account, *expected_id)
@@ -379,7 +379,7 @@ impl FTLogic {
     }
 
     async fn get_balance(&self, account: &ActorId) {
-        let encoded = hex::encode(account.as_ref());
+        let encoded = hex::encode(account.as_ref()[0..=0]);
         let id: String = encoded.chars().next().expect("Can't be None").to_string();
         if let Some(address) = self.id_to_storage.get(&id) {
             let balance = get_balance(address, account).await;

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -19,7 +19,6 @@ struct FTLogic {
     transaction_status: HashMap<H256, TransactionStatus>,
     instructions: HashMap<H256, (Instruction, Instruction)>,
     storage_code_hash: H256,
-    // id_to_storage: HashMap<String, ActorId>,
     id_to_storage: [Option<ActorId>; 16],
 }
 
@@ -338,8 +337,6 @@ impl FTLogic {
     }
 
     fn get_storage_address(&mut self, address: &ActorId) -> ActorId {
-        // let encoded = hex::encode(address.as_ref()[0..=0]);
-        // let id: String = encoded.chars().next().expect("Can't be None").to_string();
         let id = Self::get_id_for_account(address);
         if let Some(ref address) = self.id_to_storage[id] {
             *address
@@ -357,8 +354,6 @@ impl FTLogic {
     }
 
     async fn get_permit_id(&self, account: &ActorId) {
-        // let encoded = hex::encode(account.as_ref()[0..=0]);
-        // let id: String = encoded.chars().next().expect("Can't be None").to_string();
         let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             let permit_id = get_permit_id(address, account).await;
@@ -376,8 +371,6 @@ impl FTLogic {
         account: &ActorId,
         expected_id: &u128,
     ) -> bool {
-        // let encoded = hex::encode(account.as_ref()[0..=0]);
-        // let id: String = encoded.chars().next().expect("Can't be None").to_string();
         let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             return check_and_increment_permit_id(address, transaction_hash, account, *expected_id)
@@ -387,8 +380,6 @@ impl FTLogic {
     }
 
     async fn get_balance(&self, account: &ActorId) {
-        // let encoded = hex::encode(account.as_ref()[0..=0]);
-        // let id: String = encoded.chars().next().expect("Can't be None").to_string();
         let id = Self::get_id_for_account(account);
         if let Some(ref address) = self.id_to_storage[id] {
             let balance = get_balance(address, account).await;
@@ -488,12 +479,7 @@ extern "C" fn state() {
             .map(|(key, value)| (*key, value.clone()))
             .collect(),
         storage_code_hash: logic.storage_code_hash,
-        id_to_storage: logic
-            .id_to_storage
-            // .iter()
-            // .enumerate()
-            // .map(|(key, value)| (key as u8, *value))
-            // .collect(),
+        id_to_storage: logic.id_to_storage,
     };
     msg::reply(logic_state, 0).expect("Failed to share state");
 }

--- a/ft-main/tests/high_load_tests.rs
+++ b/ft-main/tests/high_load_tests.rs
@@ -29,6 +29,7 @@ fn high_load_mint() {
     }
 }
 
+#[ignore]
 #[test]
 fn high_load_transfer() {
     const FIRST_ID: u64 = 100;

--- a/ft-main/tests/high_load_tests.rs
+++ b/ft-main/tests/high_load_tests.rs
@@ -29,7 +29,6 @@ fn high_load_mint() {
     }
 }
 
-#[ignore]
 #[test]
 fn high_load_transfer() {
     const FIRST_ID: u64 = 100;


### PR DESCRIPTION
Resolves #60

Since in id_to_storage in ft-logic ids have only letters from '0' to 'f' we don't need String, we can just use array with length 16 instead of HashMap. So it removes usage of heavy hex::encode on whole [u8; 32] from ActorId and reduces usage of HashMap
 