### PR TITLE
perf: remove unnecessary blake2_256 usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
 name = "ft-storage"
 version = "2.1.4"
 dependencies = [
+ "ft-main-io",
  "ft-storage-io",
  "gear-wasm-builder",
  "gmeta",
@@ -1203,6 +1204,7 @@ dependencies = [
 name = "ft-storage-io"
 version = "2.1.2"
 dependencies = [
+ "ft-main-io",
  "gmeta",
  "gstd",
  "parity-scale-codec",

--- a/ft-logic/io/src/instruction.rs
+++ b/ft-logic/io/src/instruction.rs
@@ -1,3 +1,4 @@
+use ft_main_io::TransactionHash;
 use ft_storage_io::{FTStorageAction, FTStorageEvent};
 use gstd::{msg, prelude::*, ActorId, CodeId};
 
@@ -86,7 +87,7 @@ impl Instruction {
 }
 
 pub fn create_decrease_instruction(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     msg_source: &ActorId,
     sender_storage: &ActorId,
     sender: &ActorId,
@@ -109,7 +110,7 @@ pub fn create_decrease_instruction(
 }
 
 pub fn create_increase_instruction(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     recipient_storage: &ActorId,
     recipient: &ActorId,
     amount: u128,

--- a/ft-logic/io/src/instruction.rs
+++ b/ft-logic/io/src/instruction.rs
@@ -1,6 +1,5 @@
-use crate::H256;
 use ft_storage_io::{FTStorageAction, FTStorageEvent};
-use gstd::{msg, prelude::*, ActorId};
+use gstd::{msg, prelude::*, ActorId, CodeId};
 
 #[derive(Debug, Encode, Decode, TypeInfo, Clone)]
 pub enum InstructionState {
@@ -87,7 +86,7 @@ impl Instruction {
 }
 
 pub fn create_decrease_instruction(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     msg_source: &ActorId,
     sender_storage: &ActorId,
     sender: &ActorId,
@@ -110,7 +109,7 @@ pub fn create_decrease_instruction(
 }
 
 pub fn create_increase_instruction(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     recipient_storage: &ActorId,
     recipient: &ActorId,
     amount: u128,

--- a/ft-logic/io/src/lib.rs
+++ b/ft-logic/io/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use ft_main_io::LogicAction;
+use ft_main_io::{LogicAction, TransactionHash};
 use gmeta::{In, InOut, Metadata};
 use gstd::{prelude::*, ActorId, CodeId};
 pub struct FLogicMetadata;
@@ -14,13 +14,12 @@ impl Metadata for FLogicMetadata {
     type Signal = ();
     type State = FTLogicState;
 }
-
 #[derive(Encode, Decode, TypeInfo, Debug)]
 pub struct FTLogicState {
     pub admin: ActorId,
     pub ftoken_id: ActorId,
-    pub transaction_status: Vec<([u8; 40], TransactionStatus)>,
-    pub instructions: Vec<([u8; 40], (Instruction, Instruction))>,
+    pub transaction_status: Vec<(TransactionHash, TransactionStatus)>,
+    pub instructions: Vec<(TransactionHash, (Instruction, Instruction))>,
     pub storage_code_hash: CodeId,
     pub id_to_storage: Vec<(String, ActorId)>,
 }
@@ -35,13 +34,13 @@ pub enum TransactionStatus {
 #[derive(Debug, Encode, Decode, TypeInfo, Clone)]
 pub enum FTLogicAction {
     Message {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         account: ActorId,
         payload: Vec<u8>,
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear([u8; 40]),
+    Clear(TransactionHash),
     UpdateStorageCodeHash(CodeId),
     MigrateStorages,
 }

--- a/ft-logic/io/src/lib.rs
+++ b/ft-logic/io/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 use ft_main_io::LogicAction;
 use gmeta::{In, InOut, Metadata};
-use gstd::{prelude::*, ActorId};
-use primitive_types::H256;
+use gstd::{prelude::*, ActorId, CodeId};
 pub struct FLogicMetadata;
 pub mod instruction;
 use instruction::Instruction;
@@ -20,9 +19,9 @@ impl Metadata for FLogicMetadata {
 pub struct FTLogicState {
     pub admin: ActorId,
     pub ftoken_id: ActorId,
-    pub transaction_status: Vec<(H256, TransactionStatus)>,
-    pub instructions: Vec<(H256, (Instruction, Instruction))>,
-    pub storage_code_hash: H256,
+    pub transaction_status: Vec<([u8; 40], TransactionStatus)>,
+    pub instructions: Vec<([u8; 40], (Instruction, Instruction))>,
+    pub storage_code_hash: CodeId,
     pub id_to_storage: Vec<(String, ActorId)>,
 }
 
@@ -36,14 +35,14 @@ pub enum TransactionStatus {
 #[derive(Debug, Encode, Decode, TypeInfo, Clone)]
 pub enum FTLogicAction {
     Message {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: ActorId,
         payload: Vec<u8>,
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear(H256),
-    UpdateStorageCodeHash(H256),
+    Clear([u8; 40]),
+    UpdateStorageCodeHash(CodeId),
     MigrateStorages,
 }
 
@@ -66,5 +65,5 @@ pub struct PermitUnsigned {
 #[derive(Encode, Decode, TypeInfo)]
 pub struct InitFTLogic {
     pub admin: ActorId,
-    pub storage_code_hash: H256,
+    pub storage_code_hash: CodeId,
 }

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -7,7 +7,7 @@ use gstd::{exec, msg, prelude::*, prog::ProgramGenerator, ActorId, CodeId};
 mod messages;
 use hashbrown::HashMap;
 use messages::*;
-use primitive_types::{H512};
+use primitive_types::H512;
 
 const GAS_STORAGE_CREATION: u64 = 3_000_000_000;
 const DELAY: u32 = 600_000;
@@ -31,7 +31,12 @@ impl FTLogic {
     /// * `transaction_hash`: the hash associated with that transaction;
     /// * `account`: the account that sent the message to the main contract;
     /// * `action`: the message payload.
-    async fn message(&mut self, transaction_hash: TransactionHash, account: &ActorId, payload: &[u8]) {
+    async fn message(
+        &mut self,
+        transaction_hash: TransactionHash,
+        account: &ActorId,
+        payload: &[u8],
+    ) {
         self.assert_main_contract();
         let action = LogicAction::decode(&mut &payload[..]).expect("Can't decode `Action`");
 

--- a/ft-logic/src/lib.rs
+++ b/ft-logic/src/lib.rs
@@ -2,12 +2,12 @@
 use ft_logic_io::instruction::*;
 use ft_logic_io::*;
 use ft_main_io::LogicAction;
-use gstd::{exec, msg, prelude::*, prog::ProgramGenerator, ActorId};
+use gstd::{exec, msg, prelude::*, prog::ProgramGenerator, ActorId, CodeId};
 
 mod messages;
 use hashbrown::HashMap;
 use messages::*;
-use primitive_types::{H256, H512};
+use primitive_types::{H512};
 
 const GAS_STORAGE_CREATION: u64 = 3_000_000_000;
 const DELAY: u32 = 600_000;
@@ -16,9 +16,9 @@ const DELAY: u32 = 600_000;
 struct FTLogic {
     admin: ActorId,
     ftoken_id: ActorId,
-    transaction_status: HashMap<H256, TransactionStatus>,
-    instructions: HashMap<H256, (Instruction, Instruction)>,
-    storage_code_hash: H256,
+    transaction_status: HashMap<[u8; 40], TransactionStatus>,
+    instructions: HashMap<[u8; 40], (Instruction, Instruction)>,
+    storage_code_hash: CodeId,
     id_to_storage: HashMap<String, ActorId>,
 }
 
@@ -31,7 +31,7 @@ impl FTLogic {
     /// * `transaction_hash`: the hash associated with that transaction;
     /// * `account`: the account that sent the message to the main contract;
     /// * `action`: the message payload.
-    async fn message(&mut self, transaction_hash: H256, account: &ActorId, payload: &[u8]) {
+    async fn message(&mut self, transaction_hash: [u8; 40], account: &ActorId, payload: &[u8]) {
         self.assert_main_contract();
         let action = LogicAction::decode(&mut &payload[..]).expect("Can't decode `Action`");
 
@@ -100,7 +100,7 @@ impl FTLogic {
         }
     }
 
-    async fn mint(&mut self, transaction_hash: H256, recipient: &ActorId, amount: u128) {
+    async fn mint(&mut self, transaction_hash: [u8; 40], recipient: &ActorId, amount: u128) {
         let recipient_storage = self.get_storage_address(recipient);
 
         let result =
@@ -122,7 +122,7 @@ impl FTLogic {
 
     async fn burn(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: &ActorId,
         sender: &ActorId,
         amount: u128,
@@ -148,7 +148,7 @@ impl FTLogic {
 
     async fn transfer(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: &ActorId,
         sender: &ActorId,
         recipient: &ActorId,
@@ -214,7 +214,7 @@ impl FTLogic {
 
     async fn transfer_single_storage(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         storage_id: &ActorId,
         msg_source: &ActorId,
         sender: &ActorId,
@@ -247,7 +247,7 @@ impl FTLogic {
 
     async fn approve(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: &ActorId,
         approved_account: &ActorId,
         amount: u128,
@@ -286,7 +286,7 @@ impl FTLogic {
 
     async fn permit(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         owner: &ActorId,
         spender: &ActorId,
         amount: u128,
@@ -327,7 +327,7 @@ impl FTLogic {
         }
     }
 
-    fn update_storage_hash(&mut self, storage_code_hash: H256) {
+    fn update_storage_hash(&mut self, storage_code_hash: CodeId) {
         self.assert_admin();
         self.storage_code_hash = storage_code_hash;
     }
@@ -365,7 +365,7 @@ impl FTLogic {
 
     async fn check_and_increment_permit_id(
         &self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: &ActorId,
         expected_id: &u128,
     ) -> bool {
@@ -391,7 +391,7 @@ impl FTLogic {
         }
     }
 
-    fn clear(&mut self, transaction_hash: H256) {
+    fn clear(&mut self, transaction_hash: [u8; 40]) {
         self.transaction_status.remove(&transaction_hash);
     }
 
@@ -452,7 +452,7 @@ fn reply_ok() {
     msg::reply(FTLogicEvent::Ok, 0).expect("Error in sending a reply `FTLogicEvent::Ok`");
 }
 
-fn send_delayed_clear(transaction_hash: H256) {
+fn send_delayed_clear(transaction_hash: [u8; 40]) {
     msg::send_delayed(
         exec::program_id(),
         FTLogicAction::Clear(transaction_hash),

--- a/ft-logic/src/messages.rs
+++ b/ft-logic/src/messages.rs
@@ -1,9 +1,8 @@
-use crate::H256;
 use ft_storage_io::{FTStorageAction, FTStorageEvent};
-use gstd::{msg, ActorId};
+use gstd::{msg, ActorId, CodeId};
 
 pub async fn increase_balance(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     storage_id: &ActorId,
     account: &ActorId,
     amount: u128,
@@ -30,7 +29,7 @@ pub async fn increase_balance(
 }
 
 pub async fn decrease_balance(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     storage_id: &ActorId,
     msg_source: &ActorId,
     account: &ActorId,
@@ -59,7 +58,7 @@ pub async fn decrease_balance(
 }
 
 pub async fn approve(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     storage_id: &ActorId,
     msg_source: &ActorId,
     account: &ActorId,
@@ -88,7 +87,7 @@ pub async fn approve(
 }
 
 pub async fn transfer(
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     storage_id: &ActorId,
     msg_source: &ActorId,
     sender: &ActorId,
@@ -137,7 +136,7 @@ pub async fn get_permit_id(storage_id: &ActorId, account: &ActorId) -> u128 {
 
 pub async fn check_and_increment_permit_id(
     storage_id: &ActorId,
-    transaction_hash: H256,
+    transaction_hash: [u8; 40],
     account: &ActorId,
     expected_permit_id: u128,
 ) -> bool {

--- a/ft-logic/src/messages.rs
+++ b/ft-logic/src/messages.rs
@@ -1,8 +1,9 @@
+use ft_main_io::TransactionHash;
 use ft_storage_io::{FTStorageAction, FTStorageEvent};
 use gstd::{msg, ActorId, CodeId};
 
 pub async fn increase_balance(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     storage_id: &ActorId,
     account: &ActorId,
     amount: u128,
@@ -29,7 +30,7 @@ pub async fn increase_balance(
 }
 
 pub async fn decrease_balance(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     storage_id: &ActorId,
     msg_source: &ActorId,
     account: &ActorId,
@@ -58,7 +59,7 @@ pub async fn decrease_balance(
 }
 
 pub async fn approve(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     storage_id: &ActorId,
     msg_source: &ActorId,
     account: &ActorId,
@@ -87,7 +88,7 @@ pub async fn approve(
 }
 
 pub async fn transfer(
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     storage_id: &ActorId,
     msg_source: &ActorId,
     sender: &ActorId,
@@ -136,7 +137,7 @@ pub async fn get_permit_id(storage_id: &ActorId, account: &ActorId) -> u128 {
 
 pub async fn check_and_increment_permit_id(
     storage_id: &ActorId,
-    transaction_hash: [u8; 40],
+    transaction_hash: TransactionHash,
     account: &ActorId,
     expected_permit_id: u128,
 ) -> bool {

--- a/ft-main/io/src/lib.rs
+++ b/ft-main/io/src/lib.rs
@@ -13,11 +13,13 @@ impl Metadata for FMainTokenMetadata {
     type State = FTokenState;
 }
 
+pub type TransactionHash = [u8; 40];
+
 #[derive(Default, Encode, Decode, TypeInfo, Debug)]
 pub struct FTokenState {
     pub admin: ActorId,
     pub ft_logic_id: ActorId,
-    pub transactions: Vec<([u8; 40], TransactionStatus)>,
+    pub transactions: Vec<(TransactionHash, TransactionStatus)>,
 }
 
 #[derive(Encode, Decode, TypeInfo, Debug)]
@@ -32,7 +34,7 @@ pub enum FTokenAction {
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear([u8; 40]),
+    Clear(TransactionHash),
     MigrateStorageAddresses,
 }
 
@@ -45,7 +47,7 @@ pub enum FTokenInnerAction {
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear([u8; 40]),
+    Clear(TransactionHash),
     MigrateStorageAddresses,
 }
 

--- a/ft-main/io/src/lib.rs
+++ b/ft-main/io/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use gmeta::{In, InOut, Metadata};
-use gstd::{prelude::*, ActorId};
-use primitive_types::{H256, H512};
+use gstd::{prelude::*, ActorId, CodeId};
+use primitive_types::{H512};
 pub struct FMainTokenMetadata;
 
 impl Metadata for FMainTokenMetadata {
@@ -17,7 +17,7 @@ impl Metadata for FMainTokenMetadata {
 pub struct FTokenState {
     pub admin: ActorId,
     pub ft_logic_id: ActorId,
-    pub transactions: Vec<(H256, TransactionStatus)>,
+    pub transactions: Vec<([u8; 40], TransactionStatus)>,
 }
 
 #[derive(Encode, Decode, TypeInfo, Debug)]
@@ -27,12 +27,12 @@ pub enum FTokenAction {
         payload: LogicAction,
     },
     UpdateLogicContract {
-        ft_logic_code_hash: H256,
-        storage_code_hash: H256,
+        ft_logic_code_hash: CodeId,
+        storage_code_hash: CodeId,
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear(H256),
+    Clear([u8; 40]),
     MigrateStorageAddresses,
 }
 
@@ -40,12 +40,12 @@ pub enum FTokenAction {
 pub enum FTokenInnerAction {
     Message(Vec<u8>),
     UpdateLogicContract {
-        ft_logic_code_hash: H256,
-        storage_code_hash: H256,
+        ft_logic_code_hash: CodeId,
+        storage_code_hash: CodeId,
     },
     GetBalance(ActorId),
     GetPermitId(ActorId),
-    Clear(H256),
+    Clear([u8; 40]),
     MigrateStorageAddresses,
 }
 
@@ -87,8 +87,8 @@ pub enum FTokenEvent {
 
 #[derive(Encode, Decode, TypeInfo)]
 pub struct InitFToken {
-    pub storage_code_hash: H256,
-    pub ft_logic_code_hash: H256,
+    pub storage_code_hash: CodeId,
+    pub ft_logic_code_hash: CodeId,
 }
 
 #[derive(Encode, Decode, TypeInfo, Copy, Clone, Debug)]

--- a/ft-main/io/src/lib.rs
+++ b/ft-main/io/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use gmeta::{In, InOut, Metadata};
 use gstd::{prelude::*, ActorId, CodeId};
-use primitive_types::{H512};
+use primitive_types::H512;
 pub struct FMainTokenMetadata;
 
 impl Metadata for FMainTokenMetadata {

--- a/ft-main/src/lib.rs
+++ b/ft-main/src/lib.rs
@@ -70,7 +70,11 @@ impl FToken {
         };
     }
 
-    async fn send_message(&self, transaction_hash: TransactionHash, payload: &[u8]) -> Result<(), ()> {
+    async fn send_message(
+        &self,
+        transaction_hash: TransactionHash,
+        payload: &[u8],
+    ) -> Result<(), ()> {
         let result = msg::send_for_reply_as::<_, FTLogicEvent>(
             self.ft_logic_id,
             FTLogicAction::Message {

--- a/ft-main/src/lib.rs
+++ b/ft-main/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 use ft_logic_io::{FTLogicAction, FTLogicEvent, InitFTLogic};
 use ft_main_io::*;
-use gstd::{exec, msg, prelude::*, prog::ProgramGenerator, ActorId};
+use gstd::{exec, msg, prelude::*, prog::ProgramGenerator, ActorId, CodeId};
 use hashbrown::HashMap;
-use primitive_types::H256;
 
 const DELAY: u32 = 600_000;
 
@@ -11,7 +10,7 @@ const DELAY: u32 = 600_000;
 struct FToken {
     admin: ActorId,
     ft_logic_id: ActorId,
-    transactions: HashMap<H256, TransactionStatus>,
+    transactions: HashMap<[u8; 40], TransactionStatus>,
 }
 
 static mut FTOKEN: Option<FToken> = None;
@@ -54,7 +53,7 @@ impl FToken {
         }
     }
 
-    async fn send_message_then_reply(&mut self, transaction_hash: H256, payload: &[u8]) {
+    async fn send_message_then_reply(&mut self, transaction_hash: [u8; 40], payload: &[u8]) {
         let result = self.send_message(transaction_hash, payload).await;
         //debug!("REPLY");
         match result {
@@ -71,7 +70,7 @@ impl FToken {
         };
     }
 
-    async fn send_message(&self, transaction_hash: H256, payload: &[u8]) -> Result<(), ()> {
+    async fn send_message(&self, transaction_hash: [u8; 40], payload: &[u8]) -> Result<(), ()> {
         let result = msg::send_for_reply_as::<_, FTLogicEvent>(
             self.ft_logic_id,
             FTLogicAction::Message {
@@ -122,7 +121,7 @@ impl FToken {
         }
     }
 
-    fn update_logic_contract(&mut self, ft_logic_code_hash: H256, storage_code_hash: H256) {
+    fn update_logic_contract(&mut self, ft_logic_code_hash: CodeId, storage_code_hash: CodeId) {
         self.assert_admin();
         let (_message_id, ft_logic_id) = ProgramGenerator::create_program(
             ft_logic_code_hash.into(),
@@ -144,7 +143,7 @@ impl FToken {
         );
     }
 
-    fn clear(&mut self, transaction_hash: H256) {
+    fn clear(&mut self, transaction_hash: [u8; 40]) {
         self.transactions.remove(&transaction_hash);
     }
 }
@@ -207,13 +206,18 @@ fn reply_err() {
     msg::reply(FTokenEvent::Err, 0).expect("Error in a reply `FTokenEvent::Ok`");
 }
 
-pub fn get_hash(account: &ActorId, transaction_id: u64) -> H256 {
+pub fn get_hash(account: &ActorId, transaction_id: u64) -> [u8; 40] {
     let account: [u8; 32] = (*account).into();
     let transaction_id = transaction_id.to_be_bytes();
-    sp_core_hashing::blake2_256(&[account.as_slice(), transaction_id.as_slice()].concat()).into()
+    let mut hash = [0; 40];
+
+    hash[..32].copy_from_slice(&account);
+    hash[32..].copy_from_slice(&transaction_id);
+
+    hash
 }
 
-fn send_delayed_clear(transaction_hash: H256) {
+fn send_delayed_clear(transaction_hash: [u8; 40]) {
     msg::send_delayed(
         exec::program_id(),
         FTokenAction::Clear(transaction_hash),

--- a/ft-storage/Cargo.toml
+++ b/ft-storage/Cargo.toml
@@ -10,6 +10,7 @@ gstd.workspace = true
 ft-storage-io.workspace = true
 primitive-types.workspace = true
 hashbrown.workspace = true
+ft-main-io.workspace = true
 
 [build-dependencies]
 gmeta.workspace = true

--- a/ft-storage/io/Cargo.toml
+++ b/ft-storage/io/Cargo.toml
@@ -9,3 +9,4 @@ gstd.workspace = true
 scale-info = { version = "2", default-features = false }
 primitive-types = { version = "0.12.1", default-features = false }
 gmeta.workspace = true
+ft-main-io.workspace = true

--- a/ft-storage/io/src/lib.rs
+++ b/ft-storage/io/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use ft_main_io::TransactionHash;
 use gmeta::{InOut, Metadata};
 use gstd::{prelude::*, ActorId};
 
@@ -16,7 +17,7 @@ impl Metadata for FTStorageMetadata {
 #[derive(Default, Encode, Decode, TypeInfo, Debug)]
 pub struct FTStorageState {
     pub ft_logic_id: ActorId,
-    pub transaction_status: Vec<([u8; 40], bool)>,
+    pub transaction_status: Vec<(TransactionHash, bool)>,
     pub balances: Vec<(ActorId, u128)>,
     pub approvals: Vec<(ActorId, Vec<(ActorId, u128)>)>,
     pub permits: Vec<(ActorId, u128)>,
@@ -27,29 +28,29 @@ pub enum FTStorageAction {
     GetBalance(ActorId),
     GetPermitId(ActorId),
     IncrementPermitId {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         account: ActorId,
         expected_permit_id: u128,
     },
     IncreaseBalance {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         account: ActorId,
         amount: u128,
     },
     DecreaseBalance {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: ActorId,
         account: ActorId,
         amount: u128,
     },
     Approve {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: ActorId,
         account: ActorId,
         amount: u128,
     },
     Transfer {
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: ActorId,
         sender: ActorId,
         recipient: ActorId,

--- a/ft-storage/io/src/lib.rs
+++ b/ft-storage/io/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 use gmeta::{InOut, Metadata};
 use gstd::{prelude::*, ActorId};
-use primitive_types::H256;
 
 pub struct FTStorageMetadata;
 
@@ -17,7 +16,7 @@ impl Metadata for FTStorageMetadata {
 #[derive(Default, Encode, Decode, TypeInfo, Debug)]
 pub struct FTStorageState {
     pub ft_logic_id: ActorId,
-    pub transaction_status: Vec<(H256, bool)>,
+    pub transaction_status: Vec<([u8; 40], bool)>,
     pub balances: Vec<(ActorId, u128)>,
     pub approvals: Vec<(ActorId, Vec<(ActorId, u128)>)>,
     pub permits: Vec<(ActorId, u128)>,
@@ -28,29 +27,29 @@ pub enum FTStorageAction {
     GetBalance(ActorId),
     GetPermitId(ActorId),
     IncrementPermitId {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: ActorId,
         expected_permit_id: u128,
     },
     IncreaseBalance {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: ActorId,
         amount: u128,
     },
     DecreaseBalance {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: ActorId,
         account: ActorId,
         amount: u128,
     },
     Approve {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: ActorId,
         account: ActorId,
         amount: u128,
     },
     Transfer {
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: ActorId,
         sender: ActorId,
         recipient: ActorId,

--- a/ft-storage/src/lib.rs
+++ b/ft-storage/src/lib.rs
@@ -23,7 +23,7 @@ impl FTStorage {
 
     fn check_and_increment_permit_id(
         &mut self,
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         account: &ActorId,
         signed_permit_id: &u128,
     ) {
@@ -78,7 +78,7 @@ impl FTStorage {
     }
     fn transfer(
         &mut self,
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: &ActorId,
         sender: &ActorId,
         recipient: &ActorId,
@@ -112,7 +112,7 @@ impl FTStorage {
         }
     }
 
-    fn increase_balance(&mut self, transaction_hash: [u8; 40], account: &ActorId, amount: u128) {
+    fn increase_balance(&mut self, transaction_hash: TransactionHash, account: &ActorId, amount: u128) {
         self.assert_ft_contract();
 
         // check transaction status
@@ -136,7 +136,7 @@ impl FTStorage {
 
     fn decrease_balance(
         &mut self,
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: &ActorId,
         account: &ActorId,
         amount: u128,
@@ -166,7 +166,7 @@ impl FTStorage {
 
     fn approve(
         &mut self,
-        transaction_hash: [u8; 40],
+        transaction_hash: TransactionHash,
         msg_source: &ActorId,
         account: &ActorId,
         amount: u128,

--- a/ft-storage/src/lib.rs
+++ b/ft-storage/src/lib.rs
@@ -2,12 +2,11 @@
 use ft_storage_io::*;
 use gstd::{msg, prelude::*, ActorId};
 use hashbrown::HashMap;
-use primitive_types::H256;
 
 #[derive(Default)]
 struct FTStorage {
     ft_logic_id: ActorId,
-    transaction_status: HashMap<H256, bool>,
+    transaction_status: HashMap<[u8; 40], bool>,
     balances: HashMap<ActorId, u128>,
     approvals: HashMap<ActorId, HashMap<ActorId, u128>>,
     permits: HashMap<ActorId, u128>,
@@ -23,7 +22,7 @@ impl FTStorage {
 
     fn check_and_increment_permit_id(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         account: &ActorId,
         signed_permit_id: &u128,
     ) {
@@ -78,7 +77,7 @@ impl FTStorage {
     }
     fn transfer(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: &ActorId,
         sender: &ActorId,
         recipient: &ActorId,
@@ -112,7 +111,7 @@ impl FTStorage {
         }
     }
 
-    fn increase_balance(&mut self, transaction_hash: H256, account: &ActorId, amount: u128) {
+    fn increase_balance(&mut self, transaction_hash: [u8; 40], account: &ActorId, amount: u128) {
         self.assert_ft_contract();
 
         // check transaction status
@@ -136,7 +135,7 @@ impl FTStorage {
 
     fn decrease_balance(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: &ActorId,
         account: &ActorId,
         amount: u128,
@@ -166,7 +165,7 @@ impl FTStorage {
 
     fn approve(
         &mut self,
-        transaction_hash: H256,
+        transaction_hash: [u8; 40],
         msg_source: &ActorId,
         account: &ActorId,
         amount: u128,

--- a/ft-storage/src/lib.rs
+++ b/ft-storage/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use ft_main_io::TransactionHash;
 use ft_storage_io::*;
 use gstd::{msg, prelude::*, ActorId};
 use hashbrown::HashMap;
@@ -6,7 +7,7 @@ use hashbrown::HashMap;
 #[derive(Default)]
 struct FTStorage {
     ft_logic_id: ActorId,
-    transaction_status: HashMap<[u8; 40], bool>,
+    transaction_status: HashMap<TransactionHash, bool>,
     balances: HashMap<ActorId, u128>,
     approvals: HashMap<ActorId, HashMap<ActorId, u128>>,
     permits: HashMap<ActorId, u128>,

--- a/ft-storage/src/lib.rs
+++ b/ft-storage/src/lib.rs
@@ -112,7 +112,12 @@ impl FTStorage {
         }
     }
 
-    fn increase_balance(&mut self, transaction_hash: TransactionHash, account: &ActorId, amount: u128) {
+    fn increase_balance(
+        &mut self,
+        transaction_hash: TransactionHash,
+        account: &ActorId,
+        amount: u128,
+    ) {
         self.assert_ft_contract();
 
         // check transaction status


### PR DESCRIPTION
Resolves #62

Removed sp_core_hashing::blake2_256 in get_hash in ft-main and instead used just concat of account and transaction_id.
All appropriate changes corresponding that change.